### PR TITLE
Enable Shopify integration

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ SHOPIFY_API_KEY=your-api-key
 SHOPIFY_API_SECRET=your-api-secret
 SCOPES=read_products,write_products,read_customers,write_customers,read_metafields,write_metafields
 HOST=https://your-app.railway.app
+NEXT_PUBLIC_SHOPIFY_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Este app permite que lojistas subam uma planilha com CEPs e salve essas informa�
 ## Como rodar
 
 1. Execute `npm install` na raiz do projeto. Isso instalará as dependências do servidor e do frontend.
-2. Configure o arquivo `.env` com suas chaves do Shopify e defina `HOST` para a URL do projeto (ex.: `https://your-app.railway.app`).
+2. Configure o arquivo `.env` com suas chaves do Shopify (`SHOPIFY_API_KEY` e `SHOPIFY_API_SECRET`), defina `HOST` para a URL do projeto (ex.: `https://your-app.railway.app`) e copie o valor de `SHOPIFY_API_KEY` para `NEXT_PUBLIC_SHOPIFY_API_KEY`.
 3. Inicie o ambiente de desenvolvimento com `npm run dev`. Esse comando executa o servidor Express integrado ao Next.js.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "next": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@shopify/polaris": "^10.34.0"
+    "@shopify/polaris": "^10.34.0",
+    "@shopify/app-bridge-react": "^3.6.5"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/web/backend/server.js
+++ b/web/backend/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import next from 'next';
 import uploadCepRoutes from './routes/upload-ceps.js';
+import { shopify } from './shopify.js';
 
 const dev = process.env.NODE_ENV !== 'production';
 const nextApp = next({ dev, dir: '../frontend' });
@@ -10,6 +11,14 @@ const port = process.env.PORT || 3000;
 
 nextApp.prepare().then(() => {
   const app = express();
+  app.use(express.json());
+
+  // Shopify OAuth routes
+  app.get(shopify.config.auth.path, shopify.auth.begin());
+  app.get(shopify.config.auth.callbackPath, shopify.auth.callback());
+
+  // Protect all API routes with session validation
+  app.use('/api', shopify.validateAuthenticatedSession());
   app.use('/api', uploadCepRoutes);
 
   app.all('*', (req, res) => handle(req, res));

--- a/web/backend/shopify.js
+++ b/web/backend/shopify.js
@@ -1,4 +1,5 @@
-import { shopifyApi, LATEST_API_VERSION } from '@shopify/shopify-api'
+import '@shopify/shopify-api/adapters/node'
+import { shopifyApi, LATEST_API_VERSION, MemorySessionStorage } from '@shopify/shopify-api'
 
 export const shopify = shopifyApi({
   apiKey: process.env.SHOPIFY_API_KEY,
@@ -7,5 +8,5 @@ export const shopify = shopifyApi({
   hostName: process.env.HOST.replace(/^https?:\/\//, ''),
   apiVersion: LATEST_API_VERSION,
   isEmbeddedApp: true,
-  sessionStorage: new shopifyApi.session.MemorySessionStorage(),
+  sessionStorage: new MemorySessionStorage(),
 })

--- a/web/frontend/pages/_app.jsx
+++ b/web/frontend/pages/_app.jsx
@@ -1,10 +1,21 @@
 import '@shopify/polaris/dist/styles.css';
 import { AppProvider } from '@shopify/polaris';
+import { Provider as AppBridgeProvider } from '@shopify/app-bridge-react';
+import { useRouter } from 'next/router';
 
 export default function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+  const config = {
+    apiKey: process.env.NEXT_PUBLIC_SHOPIFY_API_KEY,
+    host: pageProps.host || router.query.host,
+    forceRedirect: true,
+  };
+
   return (
-    <AppProvider i18n={{}}>
-      <Component {...pageProps} />
-    </AppProvider>
+    <AppBridgeProvider config={config}>
+      <AppProvider i18n={{}}>
+        <Component {...pageProps} />
+      </AppProvider>
+    </AppBridgeProvider>
   );
 }

--- a/web/frontend/pages/index.jsx
+++ b/web/frontend/pages/index.jsx
@@ -35,3 +35,11 @@ export default function HomePage() {
     </Page>
   )
 }
+
+export async function getServerSideProps({ query }) {
+  return {
+    props: {
+      host: query.host || null,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add Shopify App Bridge and authentication routes
- configure MemorySessionStorage and add env variable for client key
- pass host param to pages for App Bridge
- document new environment setup

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519c7a2c208325a45e730ee6c71c23